### PR TITLE
Make Netflow data work with GeoIP filter (by adding to_i method to IP4Addr class)

### DIFF
--- a/lib/logstash/codecs/netflow/util.rb
+++ b/lib/logstash/codecs/netflow/util.rb
@@ -17,6 +17,10 @@ class IP4Addr < BinData::Primitive
   def get
     IPAddr.new_ntoh([self.storage].pack('N')).to_s
   end
+
+  def to_i
+    self.storage
+  end
 end
 
 class IP6Addr < BinData::Primitive


### PR DESCRIPTION
Trying to get the geoip filter working with netflow data, I discovered that the `IP4Addr` objects generated by the netflow codec weren't getting resolved by the `geoip` plugin. After some poking around, I discovered that the IP4Addr class needs to implement a `to_i` method (which gets called by the geoip module - see https://github.com/cjheath/geoip/blob/master/lib/geoip.rb#L873). Right now, `IP4Addr.to_i` returns something completely unusable (the first octet in decimal):

    [9] pry(main)> IP4Addr.new('172.16.201.29').to_i
    => 172

Now for some reason, geoip can't resolve data for the address `172`... :cry:

With the added `to_i` method, we get:

    [4] pry(main)> IP4Addr.new('172.16.201.29').to_i
    => 2886781213

And now my geoip filter works beautifully :grinning: