### PR TITLE
Add support for MPLS labels in flow reports

### DIFF
--- a/lib/logstash/codecs/netflow/netflow.yaml
+++ b/lib/logstash/codecs/netflow/netflow.yaml
@@ -137,7 +137,7 @@
 - :uint8
 - :mpls_top_label_type
 47:
-- :uint32
+- :ip4_addr
 - :mpls_top_label_ip_addr
 48:
 - 4
@@ -201,6 +201,36 @@
 - :skip
 69:
 - :skip
+70:
+- :mpls_stack_entry
+- :mpls_label_1
+71:
+- :mpls_stack_entry
+- :mpls_label_2
+72:
+- :mpls_stack_entry
+- :mpls_label_3
+73:
+- :mpls_stack_entry
+- :mpls_label_4
+74:
+- :mpls_stack_entry
+- :mpls_label_5
+75:
+- :mpls_stack_entry
+- :mpls_label_6
+76:
+- :mpls_stack_entry
+- :mpls_label_7
+77:
+- :mpls_stack_entry
+- :mpls_label_8
+78:
+- :mpls_stack_entry
+- :mpls_label_9
+79:
+- :mpls_stack_entry
+- :mpls_label_10
 80:
 - :mac_addr
 - :in_dst_mac

--- a/lib/logstash/codecs/netflow/util.rb
+++ b/lib/logstash/codecs/netflow/util.rb
@@ -51,6 +51,24 @@ class MacAddr < BinData::Primitive
   end
 end
 
+# The three-bit field was originally labeled 'Experimental',
+# but has since been re-named to Traffic Class (see RFC 5642)
+class MplsStackEntry < BinData::Record
+  endian :big
+
+  bit20  :label
+  bit3   :traffic_class
+  bit1   :end_of_stack
+
+  def to_i
+    self.label
+  end
+
+  def to_s
+    self.label.to_s
+  end
+end
+
 class Header < BinData::Record
   endian :big
   uint16 :version


### PR DESCRIPTION
Previously, NetFlow v9 templates with MPLS label fields in them weren't getting parsed, so any flow reports with MPLS labels in them were getting ignored. This PR adds support for flow reports containing the MPLS label stack.
- New class in `util.rb` for MPLS stack labels
- New entries in `netflow.yaml` for MPLS stack entries 1-10
- Build an array for the MPLS stack, rather than just putting the raw mpls_label_x fields on the event
- Change the type of `mpls_top_label_ip_addr` to `ip4_addr` instead of `uint32`

See also:
- [RFC 3954](https://tools.ietf.org/html/rfc3954)
- [RFC 5462](https://tools.ietf.org/html/rfc5462)
- [NetFlow Version 9 Flow-Record Format](http://www.cisco.com/en/US/technologies/tk648/tk362/technologies_white_paper09186a00800a3db9.html)
