### PR TITLE
Auto Skip feature added

### DIFF
--- a/lib/logstash/codecs/netflow.rb
+++ b/lib/logstash/codecs/netflow.rb
@@ -16,6 +16,9 @@ class LogStash::Codecs::Netflow < LogStash::Codecs::Base
   # Specify which Netflow versions you will accept.
   config :versions, :validate => :array, :default => [5, 9]
 
+  # Specify to skip undefined field automatically
+  config :auto_skip, :validate => :boolean, :default => false
+
   # Override YAML file containing Netflow field definitions
   #
   # Each Netflow field is defined like so:
@@ -256,7 +259,13 @@ class LogStash::Codecs::Netflow < LogStash::Codecs::Base
       end
     else
       @logger.warn("Unsupported field", :type => type, :length => length)
-      nil
+      if @auto_skip
+       field = [:skip]
+       field += [nil, {:length => length}] 
+       [field]
+      else
+       nil 
+      end
     end
   end # def netflow_field_for
 end # class LogStash::Filters::Netflow

--- a/lib/logstash/codecs/netflow.rb
+++ b/lib/logstash/codecs/netflow.rb
@@ -262,6 +262,7 @@ class LogStash::Codecs::Netflow < LogStash::Codecs::Base
       if @auto_skip
        field = [:skip]
        field += [nil, {:length => length}] 
+       @logger.warn("Automatically Skiped", :type => type, :length => length)
        [field]
       else
        nil 


### PR DESCRIPTION
Generally, developers facing issue with unsupported fields in Netflow. By setting auto_skip to true all unsupported fields will be skipped automatically without defining each field as skip in Netflow.yaml definitions file.

I believe it help user to develop thing faster with netflow codec.

Thanks,
Pulkit Agrawal
