### PR TITLE
Clone the field definition

### DIFF
--- a/lib/logstash/codecs/netflow.rb
+++ b/lib/logstash/codecs/netflow.rb
@@ -233,7 +233,7 @@ class LogStash::Codecs::Netflow < LogStash::Codecs::Base
 
   def netflow_field_for(type, length)
     if @fields.include?(type)
-      field = @fields[type]
+      field = @fields[type].clone
       if field.is_a?(Array)
 
         field[0] = uint_field(length, field[0]) if field[0].is_a?(Integer)


### PR DESCRIPTION
Otherwise we end up changing the field definitions. Fixes some of the issues seen in #6.