### PR TITLE
compare parsed json to avoid errors on generation order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
+## 2.0.3
+ - Fixed JSON compare flaw in specs
+
 ## 2.0.0
- - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
+ - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully,
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895
  - Dependency on logstash-core update to 2.0
 

--- a/logstash-codec-netflow.gemspec
+++ b/logstash-codec-netflow.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-netflow'
-  s.version         = '2.0.2'
+  s.version         = '2.0.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "The netflow codec is for decoding Netflow v5/v9 flows."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/codecs/netflow_spec.rb
+++ b/spec/codecs/netflow_spec.rb
@@ -1,5 +1,8 @@
+# encoding: utf-8
+
 require "logstash/devutils/rspec/spec_helper"
 require "logstash/codecs/netflow"
+require "json"
 
 describe LogStash::Codecs::Netflow do
   subject do
@@ -114,8 +117,9 @@ describe LogStash::Codecs::Netflow do
     end
 
     it "should serialize to json" do
-      expect(decode[0].to_json).to eq(json_events[0])
-      expect(decode[1].to_json).to eq(json_events[1])
+      # generated json order can change with different implementation, convert back to hash to compare.
+      expect(JSON.parse(decode[0].to_json)).to eq(JSON.parse(json_events[0]))
+      expect(JSON.parse(decode[1].to_json)).to eq(JSON.parse(json_events[1]))
     end
   end
 
@@ -201,8 +205,9 @@ describe LogStash::Codecs::Netflow do
     end
 
     it "should serialize to json" do
-      expect(decode[0].to_json).to eq(json_events[0])
-      expect(decode[1].to_json).to eq(json_events[1])
+      # generated json order can change with different implementation, convert back to hash to compare.
+      expect(JSON.parse(decode[0].to_json)).to eq(JSON.parse(json_events[0]))
+      expect(JSON.parse(decode[1].to_json)).to eq(JSON.parse(json_events[1]))
     end
   end
 end


### PR DESCRIPTION
compare json result by first parsing it into a Ruby object to avoir json implementation dependant order.

relates to elastic/logstash#4264 and elastic/logstash#4191