### PR TITLE
Update netflow.rb

### DIFF
--- a/lib/logstash/codecs/netflow.rb
+++ b/lib/logstash/codecs/netflow.rb
@@ -18,6 +18,9 @@ require "logstash/timestamp"
 # |Cisco ASA        |    | y  |       |  
 # |Cisco IOS 12.x   |    | y  |       |  
 # |fprobe           |  y |    |       |
+# |Juniper MX80     |  y |    |       | SW > 12.3R8
+# |OpenBSD pflow    |  y | n  |   y   | http://man.openbsd.org/OpenBSD-current/man4/pflow.4
+# |Mikrotik 6.35.4  |  y |    |   n   | http://wiki.mikrotik.com/wiki/Manual:IP/Traffic_Flow
 # |===========================================================================================
 #
 # ==== Usage


### PR DESCRIPTION
Added 3 Netflow/IPFIX exporters are known to work. I tested them all with current version of plugin. 

Propose to use "?" to specify case if it's should work, not tested yet and "n" if it's not supported. Empty values needs to be removed as it's meaning is not clear (unknown or not supported).

For Juniper MX series we had bug with older software version - samplerd high CPU load and no flows generated. Details there http://www.gossamer-threads.com/lists/nsp/juniper/52052 , solution was to upgrade.