### PR TITLE
Wrong include for the codec base class

### DIFF
--- a/lib/logstash/codecs/netflow.rb
+++ b/lib/logstash/codecs/netflow.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
-require "logstash/filters/base"
+require "logstash/codecs/base"
 require "logstash/namespace"
 require "logstash/timestamp"
 


### PR DESCRIPTION
When working on a new version of the documentation generator tool,
I found out that this plugin doesn't actually require the right base
class for the codec.

Since the doc tool actualy do dynamic ruby parsing the code need to be
able to run. However, this problem cannot happen in a real world situation
because the base class is loaded by other classes.

Related: https://github.com/elastic/logstash/issues/5715