### PR TITLE
Added support for variable length strings in ipfix

### DIFF
--- a/lib/logstash/codecs/netflow.rb
+++ b/lib/logstash/codecs/netflow.rb
@@ -106,8 +106,6 @@ class LogStash::Codecs::Netflow < LogStash::Codecs::Base
   # See <https://github.com/logstash-plugins/logstash-codec-netflow/blob/master/lib/logstash/codecs/netflow/ipfix.yaml> for the base set.
   config :ipfix_definitions, :validate => :path
 
-  config :included_templates, :validate => :array, :default => []
-  config :excluded_templates, :validate => :array, :default => []
   NETFLOW5_FIELDS = ['version', 'flow_seq_num', 'engine_type', 'engine_id', 'sampling_algorithm', 'sampling_interval', 'flow_records']
   NETFLOW9_FIELDS = ['version', 'flow_seq_num']
   NETFLOW9_SCOPES = {
@@ -120,8 +118,6 @@ class LogStash::Codecs::Netflow < LogStash::Codecs::Base
   IPFIX_FIELDS = ['version']
   SWITCHED = /_switched$/
   FLOWSET_ID = "flowset_id"
-  DEFAULT_INCLUDED_TEMPLATES = [2,3]
-
 
   def initialize(params = {})
     super(params)
@@ -333,12 +329,6 @@ class LogStash::Codecs::Netflow < LogStash::Codecs::Base
 
   def decode_ipfix(flowset, record)
     events = []
-    if not DEFAULT_INCLUDED_TEMPLATES.include?(record.flowset_id)
-        if (@excluded_templates.include?(record.flowset_id)) or (not @included_templates.empty? and not @included_templates.include?(record.flowset_id))
-            @logger.warn("Ignoring record.flowset_id: #{record.flowset_id}")
-            return events
-        end
-    end
 
     case record.flowset_id
     when 2

--- a/lib/logstash/codecs/netflow.rb
+++ b/lib/logstash/codecs/netflow.rb
@@ -120,6 +120,8 @@ class LogStash::Codecs::Netflow < LogStash::Codecs::Base
   IPFIX_FIELDS = ['version']
   SWITCHED = /_switched$/
   FLOWSET_ID = "flowset_id"
+  DEFAULT_INCLUDED_TEMPLATES = [2,3]
+
 
   def initialize(params = {})
     super(params)

--- a/lib/logstash/codecs/netflow/util.rb
+++ b/lib/logstash/codecs/netflow/util.rb
@@ -64,6 +64,26 @@ class ACLIdASA < BinData::Primitive
   end
 end
 
+class VarString < BinData::Primitive
+   endian :big
+   uint8 :index_1
+   uint16 :index_2 , :onlyif => lambda { index_1 == 0xff }
+   string :data, :trim_padding => true, :length => lambda { index_1 == 0xff ? index_2 : index_1 }
+
+   def get
+        self.data
+   end
+
+   def set(d)
+        self.data = d
+   end
+
+   def snapshot
+        super.encode("ASCII-8BIT", "UTF-8", invalid: :replace, undef: :replace)
+   end
+
+end
+
 class Header < BinData::Record
   endian :big
   uint16 :version


### PR DESCRIPTION
Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/

We have added support for variable length ipfix strings as well as the ability to include/exclude templates through the included_templates and excluded_templates configuration parameters.
