### PR TITLE
add variable skip and variable string support

### DIFF
--- a/lib/logstash/codecs/netflow/util.rb
+++ b/lib/logstash/codecs/netflow/util.rb
@@ -51,6 +51,36 @@ class MacAddr < BinData::Primitive
   end
 end
 
+class VarSkip < BinData::Primitive
+  endian :big
+  uint8 :length_1
+  uint16 :length_2, :onlyif => lambda { :length_1 == 255 }
+  skip :length => lambda { (length_1 == 255) ? length_2 : length_1 }
+
+  def get
+    ""
+  end
+end
+
+class VarString < BinData::Primitive
+  endian :big
+  uint8 :length_1
+  uint16 :length_2, :onlyif => lambda { :length_1 == 255 }
+  string :data, :trim_padding => true, :length => lambda { (length_1 == 255) ? length_2 : length_1 }
+
+  def set(val)
+    self.data = val
+  end
+
+  def get
+    self.data
+  end
+
+  def snapshot
+    super.encode("ASCII-8BIT", "UTF-8", invalid: :replace, undef: :replace)
+  end
+end
+
 class ACLIdASA < BinData::Primitive
   array :bytes, :type => :uint8, :initial_length => 12
 


### PR DESCRIPTION
Ref adding support for YAF (#48) an initial pr for variable length support (#49) was made.  Working through things, the pr did not remove checks that would cause templates to be excluded if a variable length item was encountered.  Also added was a method to skip fields that may be of a variable length.  The same and likely additional tests as recommended in #49 still apply.

Additional support for variable length octet type data and complex data types still required.
