### PR TITLE
Add missing field definitions to support Fortinet Netflow export

### DIFF
--- a/lib/logstash/codecs/netflow/netflow.yaml
+++ b/lib/logstash/codecs/netflow/netflow.yaml
@@ -222,6 +222,15 @@
 86:
 - :uint32
 - :in_permanent_pkts
+89:
+- :uint8
+- :forwarding_status
+95:
+- :uint32
+- :application_id
+136:
+- :uint8
+- :flow_end_reason
 148:
 - :uint32
 - :conn_id


### PR DESCRIPTION
Tested on a FortiGate 60D (v5.2.3). Fields from:
http://www.iana.org/assignments/ipfix/ipfix.xhtml