### PR TITLE
Fix/Refactor IPFIX microsecond/nanosecond interpretation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.2.1
+
+  - Fix/Refactor IPFIX microsecond/nanosecond interpretation (NTP Timestamp based)
+  - Note a possible bug in Netscaler implementation where the fraction is proabably output as microseconds
+  - Correct rspec testing for new/correct implementation of microseconds, never noticed the insane values before, mea culpa
+
 ## 3.2.0
 
   - Add Netflow v9/v10 template caching, configurable TTL

--- a/logstash-codec-netflow.gemspec
+++ b/logstash-codec-netflow.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-netflow'
-  s.version         = '3.2.0'
+  s.version         = '3.2.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "The netflow codec is for decoding Netflow v5/v9/v10 (IPFIX) flows."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/codecs/netflow_spec.rb
+++ b/spec/codecs/netflow_spec.rb
@@ -984,7 +984,7 @@ describe LogStash::Codecs::Netflow do
             "netscalerHttpReqUserAgent": "Mozilla/5.0 (Commodore 64;  kobo.com) Gecko/20100101 Firefox/75.0",
             "destinationTransportPort": 443,
             "netscalerHttpReqCookie": "beer=123456789abcdefghijklmnopqrstuvw; AnotherCookie=1234567890abcdefghijklmnopqr; Shameless.Plug=Thankyou.Rakuten.Kobo.Inc.For.Allowing.me.time.to.work.on.this.and.contribute.back.to.the.community; Padding=aaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbccccccccccccccddddddddddddddddddddddeeeeeeeeeeeeeeeeeeeeeffffffffffffffffffffffgggggggggggggggggggggggghhhhhhhhhhhhhhhhhiiiiiiiiiiiiiiiiiiiiiijjjjjjjjjjjjjjjjjjjjjjjjkkkkkkkkkkkkkkkkkklllllllllllllllmmmmmmmmmm; more=less; GJquote=There.is.no.spoon; GarrySays=Nice!!; LastPadding=aaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbcccccccccccccccccccdddddddddddeeeeeeee",
-            "flowEndMicroseconds": "503894-10-15T08:48:16.972Z",
+            "flowEndMicroseconds": "2016-11-11T12:09:19.000Z",
             "netscalerHttpReqUrl": "/aa/bb/ccccc/ddddddddddddddddddddddddd",
             "sourceIPv4Address": "192.168.0.1",
             "netscalerHttpReqMethod": "GET",
@@ -1003,7 +1003,7 @@ describe LogStash::Codecs::Netflow do
             "netscalerHttpReqVia": "1.1 akamai.net(ghost) (AkamaiGHost)",
             "netscalerConnectionId": 14460661,
             "tcpControlBits": 24,
-            "flowStartMicroseconds": "503894-10-15T08:48:16.972Z",
+            "flowStartMicroseconds": "2016-11-11T12:09:19.000Z",
             "ingressInterface": 8,
             "version": 10,
             "packetDeltaCount": 2,
@@ -1031,7 +1031,7 @@ describe LogStash::Codecs::Netflow do
       expect(decode[0].get("[netflow][version]")).to eq(10)
       expect(decode[0].get("[netflow][sourceIPv4Address]")).to eq('192.168.0.1')
       expect(decode[0].get("[netflow][destinationIPv4Address]")).to eq('10.0.0.1')
-      expect(decode[0].get("[netflow][flowEndMicroseconds]")).to eq('503894-10-15T08:48:16.970Z')
+      expect(decode[0].get("[netflow][flowEndMicroseconds]")).to eq('2016-11-11T12:09:19.000Z')
       expect(decode[0].get("[netflow][netscalerConnectionId]")).to eq(14460661)
       expect(decode[1].get("[netflow][version]")).to eq(10)
       expect(decode[1].get("[netflow][flowId]")).to eq(14460662)
@@ -1215,7 +1215,7 @@ describe LogStash::Codecs::Netflow, 'configured with template caching', :order =
     it "should decode raw data based on cached templates" do
       expect(decode.size).to eq(3)
       expect(decode[0].get("[netflow][version]")).to eq(10)
-      expect(decode[0].get("[netflow][flowEndMicroseconds]")).to eq('503894-10-15T08:48:16.970Z')
+      expect(decode[0].get("[netflow][flowEndMicroseconds]")).to eq('2016-11-11T12:09:19.000Z')
       expect(decode[0].get("[netflow][netscalerConnectionId]")).to eq(14460661)
       expect(decode[1].get("[netflow][version]")).to eq(10)
       expect(decode[1].get("[netflow][observationPointId]")).to eq(167954698)
@@ -1256,7 +1256,7 @@ describe LogStash::Codecs::Netflow, 'configured with include_flowset_id for ipfi
   it "should decode raw data" do
     expect(decode.size).to eq(3)
     expect(decode[0].get("[netflow][version]")).to eq(10)
-    expect(decode[0].get("[netflow][flowEndMicroseconds]")).to eq('503894-10-15T08:48:16.970Z')
+    expect(decode[0].get("[netflow][flowEndMicroseconds]")).to eq('2016-11-11T12:09:19.000Z')
     expect(decode[0].get("[netflow][netscalerConnectionId]")).to eq(14460661)
     expect(decode[1].get("[netflow][version]")).to eq(10)
     expect(decode[1].get("[netflow][observationPointId]")).to eq(167954698)


### PR DESCRIPTION
  - Fix/Refactor IPFIX microsecond/nanosecond interpretation (NTP Timestamp based)
  - Note a possible bug in Netscaler implementation where the fraction is proabably output as microseconds
  - Correct rspec testing for new/correct implementation of microseconds,
    never noticed the insane values before, mea culpa
