### PR TITLE
Add missing json lib import. Fixes #68

### DIFF
--- a/lib/logstash/codecs/netflow.rb
+++ b/lib/logstash/codecs/netflow.rb
@@ -3,6 +3,7 @@ require "logstash/codecs/base"
 require "logstash/namespace"
 require "logstash/timestamp"
 require "logstash/json"
+require "json"
 
 # The "netflow" codec is used for decoding Netflow v5/v9/v10 (IPFIX) flows.
 #


### PR DESCRIPTION
This library is required to load cached template files.
Without it, logstash will fail to start with a "cache file corrupt" error.
