### PR TITLE
Fix netflowv9 reduced size encoding support for 64-bit unsigned integers

### DIFF
--- a/lib/logstash/codecs/netflow.rb
+++ b/lib/logstash/codecs/netflow.rb
@@ -495,6 +495,14 @@ class LogStash::Codecs::Netflow < LogStash::Codecs::Base
           field[0] = uint_field(length, field[0])
         when :uint32
           field[0] = uint_field(length, field[0])
+        when :uint64
+          case length
+          when 5..7
+            @logger.warn("Unsupported field length encountered, skipping", :field => field, :length => length)
+            nil
+          else
+            field[0] = uint_field(length, field[0])
+          end
         when :application_id
           case length
           when 2


### PR DESCRIPTION
[ipt-netflow](https://github.com/aabc/ipt-netflow)
declares some fields defined as 64-bit (uint64) by IANA as 32-bit (uint32)
in some templates. Allow these templates to be recognised correctly.

TODO: Create `uint{40,48,56}`, to allow all other possible reduced
sizes for 64-bit unsigned integers.

Partially fixes https://github.com/logstash-plugins/logstash-codec-netflow/issues/123

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
