### PR TITLE
bugfix: respect TTL in template registry

### DIFF
--- a/lib/logstash/codecs/netflow.rb
+++ b/lib/logstash/codecs/netflow.rb
@@ -605,8 +605,8 @@ class LogStash::Codecs::Netflow < LogStash::Codecs::Base
       catch(:invalid_template) do
         yield(template) if block_given?
 
-        @bindata_spec_cache[key] = field_tuples
-        @bindata_struct_cache[key] = template
+        @bindata_spec_cache[key, @ttl] = field_tuples
+        @bindata_struct_cache[key, @ttl] = template
 
         do_persist
 


### PR DESCRIPTION
In #158, I failed to set the TTL of templates added to the registry, allowing the `Vash` default of 60s to be used.

This regrettably caused the 4.1.x issues raised by #159.