### PR TITLE
fix netflow and ipfix data type inconsistencies

### DIFF
--- a/lib/logstash/codecs/netflow.rb
+++ b/lib/logstash/codecs/netflow.rb
@@ -74,7 +74,7 @@ class LogStash::Codecs::Netflow < LogStash::Codecs::Base
   end # def register
 
   def decode(payload, metadata = nil, &block)
-#   BinData::trace_reading do
+
     header = Header.read(payload)
 
     unless @versions.include?(header.version)
@@ -88,7 +88,6 @@ class LogStash::Codecs::Netflow < LogStash::Codecs::Base
         yield(decode_netflow5(flowset, record))
       end
     elsif header.version == 9
-#     BinData::trace_reading do
       flowset = Netflow9PDU.read(payload)
       flowset.records.each do |record|
         if metadata != nil
@@ -96,19 +95,15 @@ class LogStash::Codecs::Netflow < LogStash::Codecs::Base
         else
           decode_netflow9(flowset, record).each{|event| yield(event)}
         end
-#      end
-     end
+      end
     elsif header.version == 10
-#     BinData::trace_reading do
       flowset = IpfixPDU.read(payload)
       flowset.records.each do |record|
         decode_ipfix(flowset, record).each { |event| yield(event) }
       end
-#     end
     else
       @logger.warn("Unsupported Netflow version v#{header.version}")
     end
-#   end
   rescue BinData::ValidityError, IOError => e
     @logger.warn("Invalid netflow packet received (#{e})")
   end
@@ -438,47 +433,38 @@ class LogStash::Codecs::Netflow < LogStash::Codecs::Base
   def netflow_field_for(type, length, template_id)
     if @netflow_fields.include?(type)
       field = @netflow_fields[type].clone
+      
+      return nil unless field
+
       if field.is_a?(Array)
-
-        field[0] = uint_field(length, field[0]) if field[0].is_a?(Integer)
-
-        # Small bit of fixup for:
-        # - skip or string field types where the length is dynamic
-	# - uint(8|16|24|32|64} where we use the length as specified by the
-	#   template instead of the YAML (e.g. ipv6_flow_label is 3 bytes in
-	#   the YAML and Cisco doc, but Cisco ASR9k sends 4 bytes).
-	#   Another usecase is supporting reduced-size encoding as per RFC7011 6.2
-	# - application_id where we use the length as specified by the 
-	#   template and map it to custom types for handling.
-	#   
-	case field[0]
-        when :uint8
+        if field[0].is_a?(Integer)
           field[0] = uint_field(length, field[0])
-        when :uint16
-          if length>2
-            @logger.warn("Reduced-size encoding for uint16 is larger than uint16", :field => field, :length => length)
+        else
+          case field[0]
+          when :uint8
+            field[0] = uint_field(length, field[0])
+          when :uint16
+            field[0] = uint_field(length, field[0])
+          when :uint24
+            field[0] = uint_field(length, field[0])
+          when :uint32
+            field[0] = uint_field(length, field[0])
+          when :uint48
+            field[0] = uint_field(length, field[0])
+          when :uint64
+            field[0] = uint_field(length, field[0])
+          when :skip
+            field += [nil, {:length => length.to_i}]
+          when :string
+            field = string_field(field, type, length.to_i)
+          when :octetarray
+            field[0] = :OctetArray
+            field += [{:initial_length => length.to_i}]
+          when :application_id
+            field[0] = get_rfc6759_application_id_class(field,length)
           end
-          field[0] = uint_field(length, field[0])
-        when :uint24
-          field[0] = uint_field(length, field[0])
-        when :uint32
-          if length>4
-            @logger.warn("Reduced-size encoding for uint32 is larger than uint32", :field => field, :length => length)
-          end
-          field[0] = uint_field(length, field[0])
-        when :uint64
-          if length>8
-            @logger.warn("Reduced-size encoding for uint64 is larger than uint64", :field => field, :length => length)
-          end
-          field[0] = uint_field(length, field[0])
-        when :application_id
-          field[0] = get_rfc6759_application_id_class(field,length)
-        when :skip
-          field += [nil, {:length => length.to_i}]
-        when :string
-          field = string_field(field, type, length.to_i)
         end
-
+        
         @logger.debug? and @logger.debug("Field definition complete for template #{template_id}", :field => field)
 
         [field]
@@ -506,28 +492,40 @@ class LogStash::Codecs::Netflow < LogStash::Codecs::Base
     return nil unless field
 
     if field.is_a?(Array)
-      case field[0]
-      when :skip
-        field = skip_field(field, type, length.to_i)
-      when :string
-        field = string_field(field, type, length.to_i)
-      when :octetarray
-        field[0] = :OctetArray
-        field += [{:initial_length => length.to_i}]
-      when :uint64
-        field[0] = uint_field(length, 8)
-      when :uint32
-        field[0] = uint_field(length, 4)
-      when :uint16
-        field[0] = uint_field(length, 2)
-      when :application_id
-        field[0] = get_rfc6759_application_id_class(field,length)
+      if field[0].is_a?(Integer)
+        field[0] = uint_field(length, field[0])
+      else
+        case field[0]
+        when :uint8
+          field[0] = uint_field(length, 1)
+        when :uint16
+          field[0] = uint_field(length, 2)
+        when :uint24
+          field[0] = uint_field(length, 3)
+        when :uint32
+          field[0] = uint_field(length, 4)
+        when :uint48
+          field[0] = uint_field(length, 6)
+        when :uint64
+          field[0] = uint_field(length, 8)
+        when :skip
+          field = skip_field(field, type, length.to_i)
+        when :string
+          field = string_field(field, type, length.to_i)
+        when :octetarray
+          field[0] = :OctetArray
+          field += [{:initial_length => length.to_i}]
+        when :application_id
+          field[0] = get_rfc6759_application_id_class(field,length)
+        end
       end
 
       @logger.debug("Definition complete", :field => field)
+
       [field]
     else
       @logger.warn("Definition should be an array", :field => field)
+      nil
     end
   end
 


### PR DESCRIPTION
The data types of information elements supported by IPFIX and Netflow were out of sync. This PR corrects this, as well as cleans up of this section of code and a few comments.