### PR TITLE
Fixed ArgumentError unable to initialize the plugin with Logstash 8.10+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.3.1
+  - Fixed unable to initialize the plugin with Logstash 8.10+ [#205](https://github.com/logstash-plugins/logstash-codec-netflow/pull/205)
+
 ## 4.3.0
   - Added Gigamon ipfix definitions [#199](https://github.com/logstash-plugins/logstash-codec-netflow/pull/199)
 

--- a/lib/logstash/codecs/netflow.rb
+++ b/lib/logstash/codecs/netflow.rb
@@ -57,10 +57,6 @@ class LogStash::Codecs::Netflow < LogStash::Codecs::Base
     @threadsafe = true
   end
 
-  def clone
-    self
-  end
-
   def register
     require "logstash/codecs/netflow/util"
 

--- a/lib/logstash/codecs/netflow.rb
+++ b/lib/logstash/codecs/netflow.rb
@@ -57,6 +57,10 @@ class LogStash::Codecs::Netflow < LogStash::Codecs::Base
     @threadsafe = true
   end
 
+  def clone(*args)
+    self
+  end
+
   def register
     require "logstash/codecs/netflow/util"
 

--- a/logstash-codec-netflow.gemspec
+++ b/logstash-codec-netflow.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-netflow'
-  s.version         = '4.3.0'
+  s.version         = '4.3.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads Netflow v5, Netflow v9 and IPFIX data"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Since logstash upgrade ruby from 2.6 to 3.0, this plugin has failed to initialize. According to [update to JRuby 9.4](https://github.com/elastic/logstash/pull/14861), method `clone` needs to rewrite to `clone(*args)` 

The plugin has defined its [clone](https://github.com/logstash-plugins/logstash-codec-netflow/blob/v4.3.0/lib/logstash/codecs/netflow.rb#L60), which overwrites the base class [clone](https://github.com/elastic/logstash/blob/aa05205a9eaf3a58670bc54b784fbb6b6eb297c3/logstash-core/lib/logstash/codecs/base.rb#L94). 
The codec class is wrapped by [Delegator](https://github.com/elastic/logstash/blob/aa05205a9eaf3a58670bc54b784fbb6b6eb297c3/logstash-core/lib/logstash/config/mixin.rb#L107), hence fails to initialize with `clone(freeze: )` [here](https://github.com/ruby/ruby/blob/v3_1_4/lib/delegate.rb#L226)
I believe it is not desired to redefine the method.

The commit update clone method to `clone(*args)`. It works in both ruby 2.6 and 3.0

test pipeline
```
input {
  udp {
    id => "netflow"
    port => 2055
    codec => "netflow"
    tags => ["netflow"]
  }
}
output {
  stdout { }
}
```

Fix: https://github.com/logstash-plugins/logstash-codec-netflow/issues/204