### PR TITLE
Fix failing tests after Logstash 8 support microseconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.3.2
+  - Updates the milliseconds rounding for IPFIX start/end milliseconds fields. 
+  - Fix the test to run on Logstash 8 with microseconds precision. [#206](https://github.com/logstash-plugins/logstash-codec-netflow/pull/206)
+
 ## 4.3.1
   - Fixed unable to initialize the plugin with Logstash 8.10+ [#205](https://github.com/logstash-plugins/logstash-codec-netflow/pull/205)
 

--- a/logstash-codec-netflow.gemspec
+++ b/logstash-codec-netflow.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-netflow'
-  s.version         = '4.3.1'
+  s.version         = '4.3.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads Netflow v5, Netflow v9 and IPFIX data"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/codecs/netflow_spec.rb
+++ b/spec/codecs/netflow_spec.rb
@@ -1336,7 +1336,7 @@ describe LogStash::Codecs::Netflow do
     end
 
     # in LS 8 is rounded in LS 7 is truncated
-    let(:millis) { is_LS_8 ? "882" : "881" }
+    let(:millis) { is_LS_8 ? "882" : "882" }
 
     let(:json_events) do
       events = []
@@ -2946,7 +2946,7 @@ describe LogStash::Codecs::Netflow do
     end
 
     # in LS 8 is rounded in LS 7 is truncated
-    let(:millis) { is_LS_8 ? "347" : "346" }
+    let(:millis) { is_LS_8 ? "347" : "347" }
 
     let(:json_events) do
       events = []

--- a/spec/codecs/netflow_spec.rb
+++ b/spec/codecs/netflow_spec.rb
@@ -33,13 +33,7 @@ describe LogStash::Codecs::Netflow do
       data << IO.read(File.join(File.dirname(__FILE__), "netflow5.dat"), :mode => "rb")
     end
 
-    let(:micros) do
-      if is_LS_8
-        "328"
-      else
-        ""
-      end
-    end
+    let(:micros) { is_LS_8 ? "328" : "" }
 
     let(:json_events) do
       events = []
@@ -1335,9 +1329,6 @@ describe LogStash::Codecs::Netflow do
       packets << IO.read(File.join(File.dirname(__FILE__), "ipfix_test_ixia_tpldata256.dat"), :mode => "rb")
     end
 
-    # in LS 8 is rounded in LS 7 is truncated
-    let(:millis) { is_LS_8 ? "882" : "882" }
-
     let(:json_events) do
       events = []
       events << <<-END
@@ -1348,7 +1339,7 @@ describe LogStash::Codecs::Netflow do
           "ixiaDstLongitude": 100.33540344238281,
           "ixiaHttpUserAgent": "",
           "ixiaDeviceName": "unknown",
-          "flowStartMilliseconds": "2018-10-25T12:24:19.#{millis}Z",
+          "flowStartMilliseconds": "2018-10-25T12:24:19.882Z",
           "destinationIPv4Address": "202.170.60.247",
           "ixiaDeviceId": 0,
           "ixiaL7AppName": "unknown",
@@ -2945,9 +2936,6 @@ describe LogStash::Codecs::Netflow do
       packets << IO.read(File.join(File.dirname(__FILE__), "ipfix_test_yaf_data53248.dat"), :mode => "rb")
     end
 
-    # in LS 8 is rounded in LS 7 is truncated
-    let(:millis) { is_LS_8 ? "347" : "347" }
-
     let(:json_events) do
       events = []
       events << <<-END
@@ -2995,7 +2983,7 @@ describe LogStash::Codecs::Netflow do
           "tcpSequenceNumber": 340533701,
           "silkAppLabel": 0,
           "sourceTransportPort": 63499,
-          "flowEndMilliseconds": "2016-12-25T12:58:34.#{millis}Z",
+          "flowEndMilliseconds": "2016-12-25T12:58:34.347Z",
           "flowAttributes": 0,
           "destinationIPv4Address": "172.16.32.215",
           "octetTotalCount": 172,


### PR DESCRIPTION
## Release notes

Updates the milliseconds rounding for IPFIX start/end milliseconds fields.  Fix the test to run on Logstash 8 with microseconds precision.

## What does this PR do?

Updates the tests to adapt to Logstash 8 Timestamp nanoseconds precision.
Change the way it processes milliseconds for IPFIX fields related to start/end milliseconds, switching from a truncation at milliseconds to a rounding.

## Why is it important/What is the impact to the user?

Permit to have a green CI tests.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

Run the tests against a Logstash 8 checkout:
```sh
export LOGSTASH_PATH=/tmp/logstash && export LOGSTASH_SOURCE=1
bundle install
bundle exec rspec
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Closes #203 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->