### PR TITLE
Replace File.exists? with File.exist?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.3.4
+  - Fix: replace deprecated `File.exists?` with `File.exist?` for Ruby 3.4 (JRuby 10) compatibility [#215](https://github.com/logstash-plugins/logstash-codec-netflow/pull/215)
+
 ## 4.3.3
   - Fix NoMethodError when decode fails. [214](https://github.com/logstash-plugins/logstash-codec-netflow/pull/214)
 

--- a/lib/logstash/codecs/netflow.rb
+++ b/lib/logstash/codecs/netflow.rb
@@ -401,7 +401,7 @@ class LogStash::Codecs::Netflow < LogStash::Codecs::Base
 
     # Allow the user to augment/override/rename the default fields
     if extra
-      raise "#{self.class.name}: definitions file #{extra} does not exist" unless File.exists?(extra)
+      raise "#{self.class.name}: definitions file #{extra} does not exist" unless File.exist?(extra)
       begin
         fields.merge!(YAML.load_file(extra))
       rescue Exception => e
@@ -643,7 +643,7 @@ class LogStash::Codecs::Netflow < LogStash::Codecs::Base
     ##
     # @api private
     def do_load
-      unless File.exists?(file_path)
+      unless File.exist?(file_path)
         logger.warn('Template Cache does not exist', :file_path => file_path)
         return
       end
@@ -668,7 +668,7 @@ class LogStash::Codecs::Netflow < LogStash::Codecs::Base
 
       logger.debug? and logger.debug('Writing templates to template cache', :file_path => file_path)
 
-      fail('Template Cache not writable') if File.exists?(file_path) && !File.writable?(file_path)
+      fail('Template Cache not writable') if File.exist?(file_path) && !File.writable?(file_path)
 
       do_cleanup!
 

--- a/logstash-codec-netflow.gemspec
+++ b/logstash-codec-netflow.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-codec-netflow'
-  s.version         = '4.3.3'
+  s.version         = '4.3.4'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads Netflow v5, Netflow v9 and IPFIX data"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
## Summary
- Replace `File.exists?` with `File.exist?` for Ruby 3.4 compatibility

`File.exists?` was deprecated in Ruby 3.2 and has been removed in Ruby 3.4 (JRuby 10). `File.exist?` has been the preferred method since Ruby 1.0.